### PR TITLE
Fix Devise authentication keys for employee_no only

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,5 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+Layout/LeadingCommentSpace:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "rubocop", require: false
 end
 
 gem "mysql2", "~> 0.5.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.3)
+  rubocop
   rubocop-rails-omakase
   solid_cache
   solid_queue

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -59,12 +59,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  #config.case_insensitive_keys = [ :email ]
+  # config.case_insensitive_keys = [ :email ]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  #config.strip_whitespace_keys = [ :email ]
+  # config.strip_whitespace_keys = [ :email ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/db/migrate/20251217161654_add_devise_to_employees.rb
+++ b/db/migrate/20251217161654_add_devise_to_employees.rb
@@ -3,11 +3,11 @@
 class AddDeviseToEmployees < ActiveRecord::Migration[8.0]
   def self.up
     change_table :employees do |t|
-      ## Recoverable
+      # Recoverable
       # t.string   :reset_password_token
       # t.datetime :reset_password_sent_at
 
-      ## Rememberable
+      # Rememberable
       # t.datetime :remember_created_at
     end
   end


### PR DESCRIPTION
devise.rbのemail設定をコメントアウト。今後使用予定がないのにエラーの原因になっている。