### PR TITLE
feat: switch Devise login to employee_no and fix post-login redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "thruster", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  gem "debug", require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", "~> 7.1.1", require: false

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,13 +6,24 @@ class DashboardController < ApplicationController
 
   # ALL（日別集計）
   def index
-    @course = Course.find(params[:id]) # コース取得
-    @deliveries = @course.deliveries.order(service_date: :desc) # 配達実績取得
+    @course =
+      if params[:id].present?
+        Course.find(params[:id])
+      else
+        Course.first
+      end
+
+    @deliveries = @course.deliveries.order(service_date: :desc)
   end
 
   # 単日実績
   def daily
-    @course = Course.find(params[:id])
+    @course =
+    if params[:id].present?
+      Course.find(params[:id])
+    else
+      Course.first
+    end
 
     @dates = @course.deliveries.order(service_date: :desc).pluck(:service_date) # 利用可能な日付一覧取得
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   devise_for :employees, skip: [ :registrations ]
 
   # ---------- 基本設定 ----------
-  root to: "dashboard#index" # ログイン後のトップをダッシュボードに変更
+  root to: "deliveries#new" # ログイン後のトップを配達登録画面に設定
 
   get "up" => "rails/health#show", as: :rails_health_check
 


### PR DESCRIPTION
login後の遷移先をdashboardからdelivery/#newに変更