### PR TITLE
delete @employee from deliveries-controller

### DIFF
--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -10,26 +10,23 @@ class DeliveriesController < ApplicationController
   end
 
   def create
-    employee_id = session[:employee_id] # ログイン中の社員IDを取得
-    course_id = params[:delivery][:course_id] # new画面のフォームで選ばれたコースIDを取得
-    odo_start_km = params[:delivery][:odo_start_km] # new画面のフォームで入力された出発時の走行距離を取得
-
-    @delivery = Delivery.new(
-    employee_id: employee_id,
-    course_id: course_id,
-    service_date: Date.today,
-    started_at: Time.current,
-    odo_start_km: odo_start_km,
-    odo_end_km: 0)
+    @delivery = current_employee.deliveries.new(
+      course_id: params[:delivery][:course_id],
+      service_date: Date.today,
+      started_at: Time.current,
+      odo_start_km: params[:delivery][:odo_start_km],
+      odo_end_km: 0
+    )
 
     if @delivery.save
-      redirect_to new_delivery_delivery_stop_path(@delivery),
-        notice: "コースを開始しました。"
+      redirect_to new_delivery_delivery_stop_path(@delivery), notice: "コースを開始しました。"
     else
+      Rails.logger.error("Delivery save failed: #{@delivery.errors.full_messages.inspect}")
       @courses = Course.all
       render :new, status: :unprocessable_entity
     end
   end
+
 
   def show
     @delivery = Delivery.find(params[:id])

--- a/db/migrate/20251217161654_add_devise_to_employees.rb
+++ b/db/migrate/20251217161654_add_devise_to_employees.rb
@@ -13,7 +13,7 @@ class AddDeviseToEmployees < ActiveRecord::Migration[8.0]
       # Rememberable
       t.datetime :remember_created_at
 
-      # Trackable（任意だがあると便利）
+      # Trackable（誰がいつログインしたかの記録）
       t.integer  :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at


### PR DESCRIPTION
deviceの機能追加に伴い、deliveries-controllerの@employee読み込みが不要のため、削除。