### PR TITLE
Refactor routes: use member block for deliveries#finish

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,10 @@ Rails.application.routes.draw do
 
   # ---------- 配達（Deliveries） ----------
   resources :deliveries, only: [ :index, :new, :create, :show ] do
-    patch :finish, on: :member # /deliveries/:id/finish
+    member do
+      patch :finish # /deliveries/:id/finish
+    end
+
     resources :delivery_stops, only: [ :new, :create ]
   end
 


### PR DESCRIPTION
routes.rb内、memberの記載方法をmember doに統一。
on : :memberは排除。